### PR TITLE
hack for filter name to put in header

### DIFF
--- a/lib/specgen/route-helper.js
+++ b/lib/specgen/route-helper.js
@@ -363,7 +363,7 @@ var routeHelper = module.exports = {
         if (isComplexType) {
           // paramObject.schema = schema;
           // theoretically, the param could be solely the schema object directly. However, the client doesn't support making the param a rich type yet
-          // for inline parameters as it currently becomes an object anyway. It does handle include responses well though. Not using schema at the moment
+          // for inline parameters as it currently becomes an object anyway. It does handle inline responses well though. Not using schema at the moment
           // to reduce changes.
           paramObject.type = schema.type;
           paramObject.properties = schema.properties;

--- a/lib/specgen/route-helper.js
+++ b/lib/specgen/route-helper.js
@@ -361,8 +361,18 @@ var routeHelper = module.exports = {
         var isComplexType = schema.type === 'object' ||
                             schema.$ref;
         if (isComplexType) {
-          paramObject.type = 'object';
+          // paramObject.schema = schema;
+          // theoretically, the param could be solely the schema object directly. However, the client doesn't support making the param a rich type yet
+          // for inline parameters as it currently becomes an object anyway. It does handle include responses well though. Not using schema at the moment
+          // to reduce changes.
+          paramObject.type = schema.type;
+          paramObject.properties = schema.properties;
           paramObject.format = 'JSON';
+          if (route.verb.toLowerCase() === 'get' && paramObject.name === 'filter') {
+            // bug https://github.com/OpenAPITools/openapi-generator/pull/9657
+            // means that the parameters are misformed on the URL, so put it in the header at least for find
+            paramObject.in = 'header';
+          }
           // TODO support array of primitive types
           // and map them to Swagger array of primitive types
         } else if (schema.type === 'array') {


### PR DESCRIPTION
### Description

Bug https://github.com/OpenAPITools/openapi-generator/pull/9657
means that find filters do not work properly.

This work around puts the filter in the header like the older ngx sdk.