### PR TITLE
combine descriptions for common lb data

### DIFF
--- a/lib/specgen/route-helper.js
+++ b/lib/specgen/route-helper.js
@@ -347,8 +347,17 @@ var routeHelper = module.exports = {
       var schema = schemaBuilder.buildFromLoopBackType(accepts, typeRegistry, opts);
       if (paramType === 'body') {
         // HACK: Derive the type from model
-        if (paramObject.name === 'data' && schema.type === 'object') {
-          paramObject.schema = {$ref: typeRegistry.reference(classDef.name)};
+        if (paramObject.name === 'data') {
+          if (schema.type === 'object') {
+            paramObject.schema = {$ref: typeRegistry.reference(classDef.name)};
+          } else {
+            paramObject.schema = schema;
+          }
+          // HACK: to make sure different definitions of the same thing are not duplicated just because the description changes slightly
+          if (paramObject.description === 'Model instance data') {
+            paramObject.description = 'An object of model property name/value pairs';
+          }
+
         } else {
           paramObject.schema = schema;
         }


### PR DESCRIPTION
### Description
When the schema was moved to the definitions in open api 3, if they had different descriptions, then duplicate models would be created. Standardise the descriptions so they can be reused.
