### PR TITLE
Allow force type mongo

### DIFF
--- a/lib/specgen/model-helper.js
+++ b/lib/specgen/model-helper.js
@@ -108,10 +108,9 @@ var definitionFunction = function(modelCtor, typeRegistry, options) {
         if (rel) {
           var toModel = rel.modelTo;
           if (toModel) {
-
-          var toProperties = toModel.definition.rawProperties || toModel.definition.properties;
-          var idProp = toProperties[rel.keyTo];
-          prop.forceType = idProp.forceType;
+            var toProperties = toModel.definition.rawProperties || toModel.definition.properties;
+            var idProp = toProperties[rel.keyTo];
+            prop.forceType = idProp.forceType;
           }
         }
       }

--- a/lib/specgen/model-helper.js
+++ b/lib/specgen/model-helper.js
@@ -26,7 +26,6 @@ var modelHelper = module.exports = {
    */
   registerModelDefinition: function(modelCtor, typeRegistry, opts) {
     var lbdef = modelCtor.definition;
-
     if (!lbdef) {
       // The model does not have any definition, it was most likely
       // created as a placeholder for an unknown property type
@@ -75,7 +74,6 @@ var modelHelper = module.exports = {
 
 var definitionFunction = function(modelCtor, typeRegistry, options) {
   var lbdef = modelCtor.definition;
-
   var swaggerDef = {
     description: typeConverter.convertText(
       lbdef.description || (lbdef.settings && lbdef.settings.description)
@@ -91,7 +89,6 @@ var definitionFunction = function(modelCtor, typeRegistry, options) {
   addSwaggerExtensions(lbdef.settings);
 
   var properties = lbdef.rawProperties || lbdef.properties;
-
   // Iterate through each property in the model definition.
   // Types may be defined as constructors (e.g. String, Date, etc.),
   // or as strings; swaggerSchema.buildFromLoopBackType() will take
@@ -102,10 +99,26 @@ var definitionFunction = function(modelCtor, typeRegistry, options) {
     // Hide hidden properties.
     if (modelHelper.isHiddenProperty(lbdef, key))
       return;
+    // check if foreign key if ends in Id
+    if (/Id$/.test(key)) {
+      var baseName = key.slice(0, -2);
+      if (modelCtor.settings && modelCtor.settings.relations && modelCtor.settings.relations[baseName]) {
 
+        var rel = modelCtor.relations[baseName];
+        if (rel) {
+          var toModel = rel.modelTo;
+          // console.error('key base toModel ', toModel, rel.modelTo);
+          if (toModel) {
+
+          var toProperties = toModel.definition.rawProperties || toModel.definition.properties;
+          var idProp = toProperties[rel.keyTo];
+          prop.forceType = idProp.forceType;
+          }
+        }
+      }
+    }
     // Get a type out of the constructors we were passed.
     var schema = schemaBuilder.buildFromLoopBackType(prop, typeRegistry);
-
     var desc = typeConverter.convertText(prop.description || prop.doc);
     if (desc) schema.description = desc;
 
@@ -182,11 +195,9 @@ var definitionFunction = function(modelCtor, typeRegistry, options) {
             // there above were all relation types covered in the docs
             // so we shouldn't be here -- log some error?
         }
-
         if (prop) {
           // Get a type out of the constructors we were passed.
           var schema = schemaBuilder.buildFromLoopBackType(prop, typeRegistry, options);
-
           // Assign the schema to the properties object.
           swaggerDef.properties[r] = schema;
         }

--- a/lib/specgen/model-helper.js
+++ b/lib/specgen/model-helper.js
@@ -107,7 +107,6 @@ var definitionFunction = function(modelCtor, typeRegistry, options) {
         var rel = modelCtor.relations[baseName];
         if (rel) {
           var toModel = rel.modelTo;
-          // console.error('key base toModel ', toModel, rel.modelTo);
           if (toModel) {
 
           var toProperties = toModel.definition.rawProperties || toModel.definition.properties;

--- a/lib/specgen/schema-builder.js
+++ b/lib/specgen/schema-builder.js
@@ -72,9 +72,10 @@ exports.buildFromLoopBackType = function(ldlDef, typeRegistry, opts) {
     ldlDef = {type: 'any'};
   }
 
+
   var schema = exports.buildMetadata(ldlDef);
 
-  var ldlType = ldlDef.type;
+  var ldlType = ldlDef.forceType || ldlDef.type;
   if (ldlType === 'object' && ldlDef.model) {
     // if createOnlyInstance is set, use an instance which is specifically
     // created for create operation. This instance will not contains excludeOnly
@@ -94,6 +95,7 @@ exports.buildFromLoopBackType = function(ldlDef, typeRegistry, opts) {
     var itemSchema = exports.buildFromLoopBackType(itemLdl, typeRegistry);
     schema.type = 'array';
     schema.items = itemSchema;
+
     return schema;
   }
 
@@ -104,6 +106,7 @@ exports.buildFromLoopBackType = function(ldlDef, typeRegistry, opts) {
     }
     schema.type = 'object';
     schema.properties = obj;
+
     return schema;
   }
 
@@ -132,6 +135,7 @@ exports.buildFromLoopBackType = function(ldlDef, typeRegistry, opts) {
         schema.$ref = typeRegistry.reference(ldlType);
       }
   }
+
   return schema;
 };
 

--- a/lib/specgen/swagger-spec-generator.js
+++ b/lib/specgen/swagger-spec-generator.js
@@ -114,7 +114,6 @@ module.exports = function createSwaggerObject(loopbackApplication, opts) {
   });
 
   _.assign(swaggerObject.definitions, typeRegistry.getDefinitions());
-
   swaggerObject.securityDefinitions = {
     'bearer': {
      type: 'apiKey',
@@ -123,6 +122,8 @@ module.exports = function createSwaggerObject(loopbackApplication, opts) {
      }
   }
   loopbackApplication.emit('swaggerResources', swaggerObject);
+
+
   return swaggerObject;
 };
 


### PR DESCRIPTION
### Description
This was a really annoying problem. LB Model IDs have the default of type = ObjectID. this is a string like hash that can be represented as a number, but is usable as the a string (hex) version. The existing typings already have this issue as it thinks all IDs are numbers, likewise all relations are number types. The existing application code treats them as strings and hence the new ng sdk also treats them as numbers causing an issue. 

The fix was to add a property called forceType that the swagger generator will pickup. Swagger will use this type instead of the lb type in the case that it exists.