### PR TITLE
fix get or find methods wreaking return data type for primitives

### DIFF
--- a/lib/specgen/route-helper.js
+++ b/lib/specgen/route-helper.js
@@ -105,7 +105,8 @@ var routeHelper = module.exports = {
       if (route.method.match(/\.(find|findOne|findById|__(get|findById)__*)/)) {
         var returns = route.returns;
         var type = returns[0].type;
-        var passthrough = schemaBuilder.isPrimitiveType(String(type)) || type === 'any';
+        var passthrough = schemaBuilder.isPrimitiveType(String(type)) ||
+          String(type) === 'any';
         var newType = passthrough ? type : type + 'WithRelations';
         returns[0].type = Array.isArray(type) ? [newType] : newType;
         route.returns = returns;

--- a/lib/specgen/route-helper.js
+++ b/lib/specgen/route-helper.js
@@ -105,7 +105,8 @@ var routeHelper = module.exports = {
       if (route.method.match(/\.(find|findOne|findById|__(get|findById)__*)/)) {
         var returns = route.returns;
         var type = returns[0].type;
-        var newType = type + 'WithRelations';
+        var passthrough = schemaBuilder.isPrimitiveType(String(type)) || type === 'any';
+        var newType = passthrough ? type : type + 'WithRelations';
         returns[0].type = Array.isArray(type) ? [newType] : newType;
         route.returns = returns;
       }


### PR DESCRIPTION
### Description
If a remote method starts with find or get (or some other options), you cannot return primitive data types as it adds WithRelations.

This creates errors like:
```
import { AnyWithRelationsApiModel } from '../model/models'; 
```
#### Fix
check for primitive types when returning

